### PR TITLE
fix setup.py: LONG_DESCRIPTION should be str instead of list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ URL = "https://github.com/ILTShade/MNSIM_NoC"
 
 DESCRIPTION = "Dynamic Network no Chip implementation"
 with open(os.path.join(HERE, "README.md")) as f:
-    LONG_DESCRIPTION = f.readlines()
+    LONG_DESCRIPTION = "\n".join(f.readlines())
 
 AUTHORS = "Hanbo Sun, Zhenhua Zhu, Tongxin Xie"
 EMAIL = "sunhanbo123@163.com"


### PR DESCRIPTION
`LONG_DESCRIPTION` in `setup.py` is used when installing by `python -m pip install -e .`, and reports the following errors if it is a `list` like it was originally:
```sh
...
        File "/tmp/pip-build-env-8nmr9ybp/overlay/lib/python3.11/site-packages/setuptools/_core_metadata.py", line 210, in write_pkg_file
          if not long_description.endswith("\n"):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: 'list' object has no attribute 'endswith'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.
...
```